### PR TITLE
adventure table generation

### DIFF
--- a/adventuredata.tsv
+++ b/adventuredata.tsv
@@ -1,0 +1,189 @@
+Type	Result	Sort	Definition
+ClassHeader	the kids	Core	
+ClassHeader	the NetBattlers	Extended	
+ClassHeader	the NetAgents	NetAgents	
+ClassHeader	the NetNavis	Navis	
+			
+			
+AdvHeader	at school	Core	Event
+AdvHeader	on a field trip to	Core	Location
+AdvHeader	on a weekend trip to	Core	Location
+AdvHeader	travelling by	Core	Transport
+			
+			
+HeaderResult	on exam day.	Core	Event
+HeaderResult	for the talent show.	Core	Event
+HeaderResult	in an afterschool club.	Core	Event
+HeaderResult	with a new teacher.	Core	Event
+HeaderResult	studying Viruses.	Core	Event
+HeaderResult	with a new student.	Core	Event
+			
+			
+HeaderResult	a museum.	Core	Location
+HeaderResult	a factory.	Core	Location
+HeaderResult	the aquarium.	Core	Location
+HeaderResult	the zoo.	Core	Location
+HeaderResult	the observatory.	Core	Location
+HeaderResult	a farm.	Core	Location
+HeaderResult	the woods.	Core	Location
+HeaderResult	a radio station.	Core	Location
+HeaderResult	a laboratory.	Core	Location
+HeaderResult	the power plant.	Core	Location
+HeaderResult	a canyon.	Core	Location
+HeaderResult	a mountain.	Core	Location
+HeaderResult	the beach.	Core	Location
+HeaderResult	the big city.	Core	Location
+HeaderResult	the theater.	Core	Location
+HeaderResult	a haunted house.	Core	Location
+HeaderResult	the circus.	Core	Location
+HeaderResult	a theme park.	Core	Location
+HeaderResult	a ski resort.	Core	Location
+HeaderResult	an ice rink.	Core	Location
+HeaderResult	a sports arena.	Core	Location
+HeaderResult	a cinema.	Core	Location
+HeaderResult	an arcade.	Core	Location
+HeaderResult	a music concert.	Core	Location
+			
+HeaderResult	bus.	Core	Transport
+HeaderResult	boat.	Core	Transport
+HeaderResult	plane.	Core	Transport
+HeaderResult	subway.	Core	Transport
+HeaderResult	taxi.	Core	Transport
+HeaderResult	monorail.	Core	Transport
+			
+			
+ConflictType	communication.	Extended	Social
+ConflictType	a battle.	Extended	Battle
+ConflictType	a puzzle.	Extended	Puzzle
+ConflictType	a dungeon.	Extended	Dungeon
+ConflictType	a race.	Extended	Race
+ConflictType	a spectated competition.	Extended	Audience
+ConflictType	between the party.	Extended	PvP
+ConflictType	taking sides.	Extended	PvP
+			
+			
+ConflictHeader	an evildoer is there to	Core	Evil
+ConflictHeader	a computer is there to	Extended	Neutral
+ConflictHeader	a ghost is there to	Extended	Neutral
+ConflictHeader	a monster is there to	Extended	Neutral
+ConflictHeader	a vampire is there to	Extended	Neutral
+ConflictHeader	a robot is there to	Extended	Neutral
+			
+			
+ConflictResult	steal something secret.	Core	Evil
+ConflictResult	destroy something valuable.	Core	Evil
+ConflictResult	get revenge on someone.	Core	Evil
+ConflictResult	take people hostage.	Core	Evil
+ConflictResult	steal something famous.	Core	Evil
+ConflictResult	destroy something beloved.	Core	Evil
+			
+			
+VulnResult	their overconfidence.	Core	Evil
+VulnResult	their incompetent henchmen.	Core	Evil
+VulnResult	something they left behind.	Core	Evil
+VulnResult	something the kids overhear.	Core	Evil
+VulnResult	their paranoia.	Core	Evil
+VulnResult	something they underestimated.	Core	Evil
+			
+			
+NPCFirstName	Vi	Core	
+NPCFirstName	Alma	Core	
+NPCFirstName	Bit	Core	
+NPCFirstName	Byte	Core	
+NPCFirstName	Sofia	Core	
+NPCFirstName	Ada	Core	
+NPCFirstName	Olive	Core	
+NPCFirstName	Vim	Core	
+NPCFirstName	Raj	Core	
+NPCFirstName	Haskell	Core	
+NPCFirstName	Dorothy	Core	
+NPCFirstName	Penny	Core	
+NPCFirstName	Miki	Core	
+NPCFirstName	Lou	Core	
+NPCFirstName	Anne	Core	
+NPCFirstName	Ramesh	Core	
+NPCFirstName	Tux	Core	
+NPCFirstName	Rico	Core	
+NPCFirstName	Akari	Core	
+NPCFirstName	Dev	Core	
+NPCFirstName	Winnie	Core	
+NPCFirstName	Alice	Core	
+NPCFirstName	Afua	Core	
+NPCFirstName	Katherine	Core	
+NPCFirstName	Rosa	Core	
+NPCFirstName	Pepper	Core	
+NPCFirstName	Sparky	Core	
+NPCFirstName	Masa	Core	
+NPCFirstName	Darwin	Core	
+NPCFirstName	Amma	Core	
+NPCFirstName	Dev	Core	
+NPCFirstName	Archie	Core	
+NPCFirstName	Bee	Core	
+NPCFirstName	Kim	Core	
+NPCFirstName	Lisa	Core	
+NPCFirstName	George	Core	
+			
+			
+Personality	an enthusiastic	Core	
+Personality	a dopey	Core	
+Personality	a skeptic	Core	
+Personality	a daydreamy	Core	
+Personality	a nervous	Core	
+Personality	a know-it-all	Core	
+			
+			
+Occupation	student	Core	
+Occupation	Official	Core	
+Occupation	teacher	Core	
+Occupation	businessperson	Core	
+Occupation	stay-at-home	Core	
+Occupation	artist	Core	
+			
+			
+Feature	their hair	Core	
+Feature	their face	Core	
+Feature	their clothes	Core	
+Feature	their voice	Core	
+Feature	their physical mannerisms	Core	
+Feature	an item they have	Core	
+			
+			
+NaviHostility	friendliness	Extended	
+NaviHostility	hostility	Extended	
+NaviHostility	deception	Extended	
+NaviHostility	antagonism	Extended	
+NaviHostility	bitterness	Extended	
+NaviHostility	joyfulness	Extended	
+NaviHostility	approval	Extended	
+NaviHostility	malice	Extended	
+NaviHostility	a killing intent	Extended	
+NaviHostility	pride	Extended	
+NaviHostility	disgust	Extended	
+NaviHostility	elation	Extended	
+NaviHostility	great interest	Extended	
+NaviHostility	fear	Extended	
+NaviHostility	silliness	Extended	
+NaviHostility	relief	Extended	
+NaviHostility	bravery	Extended	
+NaviHostility	dishonesty	Extended	
+NaviHostility	curiosity	Extended	
+NaviHostility	confusion	Extended	
+NaviHostility	envy	Extended	
+NaviHostility	mercy	Extended	
+NaviHostility	confidence	Extended	
+NaviHostility	elegance	Extended	
+NaviHostility	love	Extended	
+NaviHostility	compassion	Extended	
+NaviHostility	coldness	Extended	
+NaviHostility	anticipation	Extended	
+NaviHostility	chaos	Extended	
+NaviHostility	anxiety	Extended	
+NaviHostility	annoyance	Extended	
+NaviHostility	amazement	Extended	
+NaviHostility	narcissism	Extended	
+NaviHostility	determination	Extended	
+NaviHostility	despair	Extended	
+NaviHostility	riches	Extended	
+NaviHostility	brutality	Extended	
+NaviHostility	hope	Extended	
+NaviHostility	unreality	Extended	

--- a/commands.txt
+++ b/commands.txt
@@ -56,3 +56,4 @@ pmr	repo	prefix	1
 playermade	repo	prefix	1
 pmc	repo	prefix	1
 adventure	adventure	prefix	1
+sheet	sheet	prefix	1

--- a/commands.txt
+++ b/commands.txt
@@ -55,3 +55,4 @@ repo	repo	prefix	1
 pmr	repo	prefix	1
 playermade	repo	prefix	1
 pmc	repo	prefix	1
+adventure	adventure	prefix	1

--- a/helpresponses.tsv
+++ b/helpresponses.tsv
@@ -2,6 +2,7 @@ Command	Alias	Type	Hidden?	Ruling?	Response
 roll	r	Rollers	FALSE		Rolls a number of X-sided dice, including success/fail thresholds or additional hits.
 repeatroll	rr, repeatr	Rollers	FALSE		Repeats a roll X times. Uses the same dice algebra as `{cp}roll`.
 rulebook		Lookups	FALSE		Pulls up links for the NetBattlers rulebooks.
+sheet		Lookups	FALSE		Pulls up a link to the NetBattlers blank character sheet.
 repo	pmr, pmc, playermade	Lookups	FALSE		This command can pull up and search for player-made content on the official Notion Player-Made Repository. Type `{cp}repo` to learn more!
 					
 stats	skills, stat, skill	Reminders (Base)	FALSE		All characters, ranging from Navis to Viruses, have **three stats** and **nine skills**, with each stat having three related skills.\n> **Mind:** Sense, Info, Coding\n> **Body:** Strength, Speed, Stamina\n> **Soul:** Charm, Bravery, Affinity\nWhen rolling skills, the player adds the skill and the related stat, then rolls that many dice. For more information on each skill, try using `{cp}help!` (i.e. `{cp}help speed`)\n\nSkills cannot be reduced below 0. Stats cannot be reduced below 1.\n**NetOps:** Skills cannot exceed 5. Stats cannot exceed 3.\n**Navis:** Skills cannot exceed 5. Stats cannot exceed 4.

--- a/main.py
+++ b/main.py
@@ -2451,14 +2451,14 @@ async def adventure_master(context, args):
     # All of the randomization is done initially for the Chaos preset.
 
     # The following sorting mechanisms have been removed until more options have been created for them.
-    # Atmosphere, NPC last names, vulnerability header
+    # Atmosphere, NPC last names, vulnerability header, some sort/definition rules that are needed in later iterations
 # -----------------------------------------------------------------------
 # Classification headers (for the type of adventure the generator sorts from)
 # These three work together (Except core rulebook doesn't really care about ClassHeader, for now.)
 
     classdf_sub = adventure_df[adventure_df["Type"] == "ClassHeader"]
     row_num = random.randint(1, classdf_sub.shape[0]) - 1
-    sort_class = [classdf_sub.iloc[row_num]["Sort"]]
+    # sort_class = [classdf_sub.iloc[row_num]["Sort"]]
     class_header = [classdf_sub.iloc[row_num]["Result"]]
 
 # Adventure headers
@@ -2491,20 +2491,20 @@ async def adventure_master(context, args):
 
     conflictheaddf_sub = adventure_df[adventure_df["Type"] == "ConflictHeader"]
     row_num = random.randint(1, conflictheaddf_sub.shape[0]) - 1
-    sort_conflicthead = [conflictheaddf_sub.iloc[row_num]["Sort"]]
-    define_conflicthead = [conflictheaddf_sub.iloc[row_num]["Definition"]]
+    # sort_conflicthead = [conflictheaddf_sub.iloc[row_num]["Sort"]]
+    # define_conflicthead = [conflictheaddf_sub.iloc[row_num]["Definition"]]
     conflict_header = [conflictheaddf_sub.iloc[row_num]["Result"]]
 
     conflictresultdf_sub = adventure_df[adventure_df["Type"] == "ConflictResult"]
     row_num = random.randint(1, conflictresultdf_sub.shape[0]) - 1
     sort_conflictresult = [conflictresultdf_sub.iloc[row_num]["Sort"]]
-    define_conflictresult = [conflictresultdf_sub.iloc[row_num]["Definition"]]
+    # define_conflictresult = [conflictresultdf_sub.iloc[row_num]["Definition"]]
     conflict_result = [conflictresultdf_sub.iloc[row_num]["Result"]]
 
     vulnresdf_sub = adventure_df[adventure_df["Type"] == "VulnResult"]
     row_num = random.randint(1, vulnresdf_sub.shape[0]) - 1
     sort_vulnres = [vulnresdf_sub.iloc[row_num]["Sort"]]
-    define_vulnres = [vulnresdf_sub.iloc[row_num]["Definition"]]
+    # define_vulnres = [vulnresdf_sub.iloc[row_num]["Definition"]]
     vuln_result = [vulnresdf_sub.iloc[row_num]["Result"]]
 
 # -----------------------------------------------------------------------
@@ -2567,7 +2567,7 @@ async def adventure_master(context, args):
         while sort_conflictresult[0].lower() != 'core':
             row_num = random.randint(1, conflictresultdf_sub.shape[0]) - 1
             sort_conflictresult = [conflictresultdf_sub.iloc[row_num]["Sort"]]
-            define_conflictresult = [conflictresultdf_sub.iloc[row_num]["Definition"]]
+            # define_conflictresult = [conflictresultdf_sub.iloc[row_num]["Definition"]]
             conflict_result = [conflictresultdf_sub.iloc[row_num]["Result"]]
 
         while sort_npcfirst[0].lower() != 'core':
@@ -2593,7 +2593,7 @@ async def adventure_master(context, args):
         while sort_vulnres[0].lower() != 'core':
             row_num = random.randint(1, vulnresdf_sub.shape[0]) - 1
             sort_vulnres = [vulnresdf_sub.iloc[row_num]["Sort"]]
-            define_vulnres = [vulnresdf_sub.iloc[row_num]["Definition"]]
+            # define_vulnres = [vulnresdf_sub.iloc[row_num]["Definition"]]
             vuln_result = [vulnresdf_sub.iloc[row_num]["Result"]]
 
         generated_msg = "The adventure starts with the kids {} {} " + \

--- a/main.py
+++ b/main.py
@@ -169,6 +169,7 @@ pmc_link = rulebook_df[rulebook_df["Name"] == "Player-Made Repository"]["Link"].
 nyx_link = rulebook_df[rulebook_df["Name"] == "Nyx"]["Link"].iloc[0]
 rulebook_df = rulebook_df[(rulebook_df["Name"] != "Player-Made Repository") & (rulebook_df["Name"] != "Nyx")]
 
+adventure_df = pd.read_csv(r"adventuredata.tsv", sep="\t").fillna('')
 
 parser = dice_algebra.parser
 lexer = dice_algebra.lexer
@@ -2431,19 +2432,18 @@ async def repo(context, *args, **kwargs):
 
 async def adventure(context, *args, **kwargs):
     cleaned_args = clean_args(args)
-    if (len(cleaned_args) < 1):
+    if len(cleaned_args) < 1:
         cleaned_args.append("core")
-    if (cleaned_args[0] == 'help'):
+    if cleaned_args[0] == 'help':
         adventure_help_msg = "I can generate an adventure for you! Specify `{cp}adventure` with the type of story you'd like!\n" + \
                              "*Core, Chaos*"
         return await koduck.sendmessage(context["message"], sendcontent=adventure_help_msg.replace("{cp}", settings.commandprefix))
-    if (len(cleaned_args) > 1):
+    if len(cleaned_args) > 1:
         return await koduck.sendmessage(context["message"],
                                         sendcontent="I can only generate one adventure at a time!")
     await adventure_master(context, cleaned_args)
 
 async def adventure_master(context, args):
-    arg = args[0]
 # -----------------------------------------------------------------------
 # ADVENTURE HEADERS
     # The "Sort" column controls how the data is sorted between the option presets.
@@ -2454,7 +2454,6 @@ async def adventure_master(context, args):
     # Atmosphere, NPC last names, vulnerability header
 # -----------------------------------------------------------------------
 # Classification headers (for the type of adventure the generator sorts from)
-
 # These three work together (Except core rulebook doesn't really care about ClassHeader, for now.)
 
     classdf_sub = adventure_df[adventure_df["Type"] == "ClassHeader"]
@@ -2552,7 +2551,7 @@ async def adventure_master(context, args):
     row_num = random.randint(1, navihostilitydf_sub.shape[0]) - 1
     navi_hostility = [navihostilitydf_sub.iloc[row_num]["Result"]]
 
-    if (args[0] == 'core'):
+    if args[0] == 'core':
         while sort_advheader[0].lower() != 'core':
             row_num = random.randint(1, advheaddf_sub.shape[0]) - 1
             sort_advheader = [advheaddf_sub.iloc[row_num]["Sort"]]
@@ -2606,7 +2605,7 @@ async def adventure_master(context, args):
                                                                          *npc_feature, *vuln_result))
 #   TODO:
 #    if (args[0] == 'extended'):
-    if (args[0] == 'chaos'):
+    if args[0] == 'chaos':
         generated_msg = "The adventure starts with {} {} {} " + \
                         "But {} {} Their vulnerability is {}\n" + \
                         "**{}** is {} {}, notable for {}.\n" + \

--- a/main.py
+++ b/main.py
@@ -2622,6 +2622,12 @@ async def adventure_master(context, args):
         return await koduck.sendmessage(context["message"],
                                         sendcontent="Please specify either Core or Chaos.")
 
+
+async def sheet(context, *args, **kwargs):
+    return await koduck.sendmessage(context["message"],
+                                    sendcontent="*NetBattlers Blank Character Sheet:* __<https://docs.google.com/spreadsheets/d/158iI4LCpfS4AGjV5EshHkbKUD4GxogJCiwZCV6QzJ5s>__")
+
+
 def setup():
     koduck.addcommand("updatecommands", updatecommands, "prefix", 3)
 

--- a/main.py
+++ b/main.py
@@ -2429,6 +2429,199 @@ async def repo(context, *args, **kwargs):
         return await koduck.sendmessage(context["message"],
                                         sendcontent=generated_msg.format(size, user_query))
 
+async def adventure(context, *args, **kwargs):
+    cleaned_args = clean_args(args)
+    if (len(cleaned_args) < 1):
+        cleaned_args.append("core")
+    if (cleaned_args[0] == 'help'):
+        adventure_help_msg = "I can generate an adventure for you! Specify `{cp}adventure` with the type of story you'd like!\n" + \
+                             "*Core, Chaos*"
+        return await koduck.sendmessage(context["message"], sendcontent=adventure_help_msg.replace("{cp}", settings.commandprefix))
+    if (len(cleaned_args) > 1):
+        return await koduck.sendmessage(context["message"],
+                                        sendcontent="I can only generate one adventure at a time!")
+    await adventure_master(context, cleaned_args)
+
+async def adventure_master(context, args):
+    arg = args[0]
+# -----------------------------------------------------------------------
+# ADVENTURE HEADERS
+    # The "Sort" column controls how the data is sorted between the option presets.
+    # The "Definition" column controls the filtering rules for grammar correction.
+    # All of the randomization is done initially for the Chaos preset.
+
+    # The following sorting mechanisms have been removed until more options have been created for them.
+    # Atmosphere, NPC last names, vulnerability header
+# -----------------------------------------------------------------------
+# Classification headers (for the type of adventure the generator sorts from)
+
+# These three work together (Except core rulebook doesn't really care about ClassHeader, for now.)
+
+    classdf_sub = adventure_df[adventure_df["Type"] == "ClassHeader"]
+    row_num = random.randint(1, classdf_sub.shape[0]) - 1
+    sort_class = [classdf_sub.iloc[row_num]["Sort"]]
+    class_header = [classdf_sub.iloc[row_num]["Result"]]
+
+# Adventure headers
+# Corresponds to the header table in the book. Extended for customization.
+
+    advheaddf_sub = adventure_df[adventure_df["Type"] == "AdvHeader"]
+    row_num = random.randint(1, advheaddf_sub.shape[0]) - 1
+    sort_advheader = [advheaddf_sub.iloc[row_num]["Sort"]]
+    define_advheader = [advheaddf_sub.iloc[row_num]["Definition"]]
+    adv_header = [advheaddf_sub.iloc[row_num]["Result"]]
+
+# Header results
+# Corresponds to the results table in the book.
+
+    headresultdf_sub = adventure_df[adventure_df["Type"] == "HeaderResult"]
+    row_num = random.randint(1, headresultdf_sub.shape[0]) - 1
+    sort_headresult = [headresultdf_sub.iloc[row_num]["Sort"]]
+    define_headresult = [headresultdf_sub.iloc[row_num]["Definition"]]
+    header_result = [headresultdf_sub.iloc[row_num]["Result"]]
+
+# -----------------------------------------------------------------------
+# Element generation. Just borrowed the element picker code for this.
+
+    navi_element = 1
+    navi_element = random.sample(range(element_df.shape[0]), navi_element)
+    navi_element = [element_df.iloc[i]["element"] for i in navi_element]
+
+# -----------------------------------------------------------------------
+# Conflict generators. Headers for conflicts and vulnerabilities primarily exist for homebrew tables.
+
+    conflictheaddf_sub = adventure_df[adventure_df["Type"] == "ConflictHeader"]
+    row_num = random.randint(1, conflictheaddf_sub.shape[0]) - 1
+    sort_conflicthead = [conflictheaddf_sub.iloc[row_num]["Sort"]]
+    define_conflicthead = [conflictheaddf_sub.iloc[row_num]["Definition"]]
+    conflict_header = [conflictheaddf_sub.iloc[row_num]["Result"]]
+
+    conflictresultdf_sub = adventure_df[adventure_df["Type"] == "ConflictResult"]
+    row_num = random.randint(1, conflictresultdf_sub.shape[0]) - 1
+    sort_conflictresult = [conflictresultdf_sub.iloc[row_num]["Sort"]]
+    define_conflictresult = [conflictresultdf_sub.iloc[row_num]["Definition"]]
+    conflict_result = [conflictresultdf_sub.iloc[row_num]["Result"]]
+
+    vulnresdf_sub = adventure_df[adventure_df["Type"] == "VulnResult"]
+    row_num = random.randint(1, vulnresdf_sub.shape[0]) - 1
+    sort_vulnres = [vulnresdf_sub.iloc[row_num]["Sort"]]
+    define_vulnres = [vulnresdf_sub.iloc[row_num]["Definition"]]
+    vuln_result = [vulnresdf_sub.iloc[row_num]["Result"]]
+
+# -----------------------------------------------------------------------
+# Extended generator tables.
+
+    conflicttypedf_sub = adventure_df[adventure_df["Type"] == "ConflictType"]
+    row_num = random.randint(1, conflicttypedf_sub.shape[0]) - 1
+    conflict_type = [conflicttypedf_sub.iloc[row_num]["Result"]]
+
+# -----------------------------------------------------------------------
+# Generators for human beings.
+# Although with the NBC you never know, it might be for ghosts instead.
+# First name generator corresponds to the first names in the Core book. Last names are homebrew.
+# Maybe to-do navi names too?
+
+    npcfirstdf_sub = adventure_df[adventure_df["Type"] == "NPCFirstName"]
+    row_num = random.randint(1, npcfirstdf_sub.shape[0]) - 1
+    sort_npcfirst = [npcfirstdf_sub.iloc[row_num]["Sort"]]
+    npc_firstname = [npcfirstdf_sub.iloc[row_num]["Result"]]
+
+# -----------------------------------------------------------------------
+# these use the same tables, just need individual results
+    npcpersonalitydf_sub = adventure_df[adventure_df["Type"] == "Personality"]
+    row_num = random.randint(1, npcpersonalitydf_sub.shape[0]) - 1
+    sort_npcpersonality = [npcpersonalitydf_sub.iloc[row_num]["Sort"]]
+    npc_personality = [npcpersonalitydf_sub.iloc[row_num]["Result"]]
+
+    navipersonalitydf_sub = adventure_df[adventure_df["Type"] == "Personality"]
+    row_num = random.randint(1, navipersonalitydf_sub.shape[0]) - 1
+    navi_personality = [navipersonalitydf_sub.iloc[row_num]["Result"]]
+# -----------------------------------------------------------------------
+
+    npcoccupationdf_sub = adventure_df[adventure_df["Type"] == "Occupation"]
+    row_num = random.randint(1, npcoccupationdf_sub.shape[0]) - 1
+    sort_npcoccupation = [npcoccupationdf_sub.iloc[row_num]["Sort"]]
+    npc_occupation = [npcoccupationdf_sub.iloc[row_num]["Result"]]
+
+    npcfeaturedf_sub = adventure_df[adventure_df["Type"] == "Feature"]
+    row_num = random.randint(1, npcfeaturedf_sub.shape[0]) - 1
+    sort_npcfeature = [npcfeaturedf_sub.iloc[row_num]["Sort"]]
+    npc_feature = [npcfeaturedf_sub.iloc[row_num]["Result"]]
+
+    navihostilitydf_sub = adventure_df[adventure_df["Type"] == "NaviHostility"]
+    row_num = random.randint(1, navihostilitydf_sub.shape[0]) - 1
+    navi_hostility = [navihostilitydf_sub.iloc[row_num]["Result"]]
+
+    if (args[0] == 'core'):
+        while sort_advheader[0].lower() != 'core':
+            row_num = random.randint(1, advheaddf_sub.shape[0]) - 1
+            sort_advheader = [advheaddf_sub.iloc[row_num]["Sort"]]
+            define_advheader = [advheaddf_sub.iloc[row_num]["Definition"]]
+            adv_header = [advheaddf_sub.iloc[row_num]["Result"]]
+
+        while sort_headresult[0].lower() != 'core' or define_headresult[0] != define_advheader[0]:
+            row_num = random.randint(1, headresultdf_sub.shape[0]) - 1
+            sort_headresult = [headresultdf_sub.iloc[row_num]["Sort"]]
+            define_headresult = [headresultdf_sub.iloc[row_num]["Definition"]]
+            header_result = [headresultdf_sub.iloc[row_num]["Result"]]
+
+        while sort_conflictresult[0].lower() != 'core':
+            row_num = random.randint(1, conflictresultdf_sub.shape[0]) - 1
+            sort_conflictresult = [conflictresultdf_sub.iloc[row_num]["Sort"]]
+            define_conflictresult = [conflictresultdf_sub.iloc[row_num]["Definition"]]
+            conflict_result = [conflictresultdf_sub.iloc[row_num]["Result"]]
+
+        while sort_npcfirst[0].lower() != 'core':
+            row_num = random.randint(1, npcfirstdf_sub.shape[0]) - 1
+            sort_npcfirst = [npcfirstdf_sub.iloc[row_num]["Sort"]]
+            npc_firstname = [npcfirstdf_sub.iloc[row_num]["Result"]]
+
+        while sort_npcpersonality[0].lower() != 'core':
+            row_num = random.randint(1, npcpersonalitydf_sub.shape[0]) - 1
+            sort_npcpersonality = [npcpersonalitydf_sub.iloc[row_num]["Sort"]]
+            npc_personality = [npcpersonalitydf_sub.iloc[row_num]["Result"]]
+
+        while sort_npcoccupation[0].lower() != 'core':
+            row_num = random.randint(1, npcoccupationdf_sub.shape[0]) - 1
+            sort_npcoccupation = [npcoccupationdf_sub.iloc[row_num]["Sort"]]
+            npc_occupation = [npcoccupationdf_sub.iloc[row_num]["Result"]]
+
+        while sort_npcfeature[0].lower() != 'core':
+            row_num = random.randint(1, npcfeaturedf_sub.shape[0]) - 1
+            sort_npcfeature = [npcfeaturedf_sub.iloc[row_num]["Sort"]]
+            npc_feature = [npcfeaturedf_sub.iloc[row_num]["Result"]]
+
+        while sort_vulnres[0].lower() != 'core':
+            row_num = random.randint(1, vulnresdf_sub.shape[0]) - 1
+            sort_vulnres = [vulnresdf_sub.iloc[row_num]["Sort"]]
+            define_vulnres = [vulnresdf_sub.iloc[row_num]["Definition"]]
+            vuln_result = [vulnresdf_sub.iloc[row_num]["Result"]]
+
+        generated_msg = "The adventure starts with the kids {} {} " + \
+                        "But an evildoer is there to {} Their name is **{}**, and they are {} {}, notable for {}. Their vulnerability is {}\n"
+        return await koduck.sendmessage(context["message"],
+                                        sendcontent=generated_msg.format(*adv_header, *header_result,
+                                                                         *conflict_result, *npc_firstname,
+                                                                         *npc_personality, *npc_occupation,
+                                                                         *npc_feature, *vuln_result))
+#   TODO:
+#    if (args[0] == 'extended'):
+    if (args[0] == 'chaos'):
+        generated_msg = "The adventure starts with {} {} {} " + \
+                        "But {} {} Their vulnerability is {}\n" + \
+                        "**{}** is {} {}, notable for {}.\n" + \
+                        "Next, {} meet {} navi with the element of {} that greets them with {}.\n" + \
+                        "The primary conflict is {}"
+        return await koduck.sendmessage(context["message"],
+                                        sendcontent=generated_msg.format(*class_header, *adv_header, *header_result,
+                                                                         *conflict_header, *conflict_result,
+                                                                         *vuln_result,
+                                                                         *npc_firstname, *npc_personality,
+                                                                         *npc_occupation, *npc_feature, *class_header,
+                                                                         *navi_personality, *navi_element, *navi_hostility, *conflict_type))
+    else:
+        return await koduck.sendmessage(context["message"],
+                                        sendcontent="Please specify either Core or Chaos.")
 
 def setup():
     koduck.addcommand("updatecommands", updatecommands, "prefix", 3)


### PR DESCRIPTION
adventure
- takes either no parameter, help parameter, `core` parameter, or `chaos` parameter.
- `core` parameter will generate adventures according to the header tables in the book.
- `chaos` parameter will generate adventures with a little extra stuff homebrew. because the tables of the new stuff i had planned is incomplete currently, i decided to go ahead and get this feature up and going as-is just so we have it for vanilla netbattlers compatibility.
- the code is not great, i will refine it later on, adding more rules and table generators and rewriting the shitbox filtering code.
- i asked iza to add the current working copy of the adventuredata.tsv on gdrive where we maintain the datasets. for any alterations, perform them there.

sheet
- takes no parameters. links a blank netbattlers sheet. we agreed on hardcoding it for now per the official rulebook's own links.